### PR TITLE
Make WhatsApp web version configurable and add local webVersion cache dir

### DIFF
--- a/gategpt/GateGPT/messaging.js
+++ b/gategpt/GateGPT/messaging.js
@@ -32,6 +32,10 @@ function initMessaging({ onMessage, onCall, onReady }) {
   const QR_PNG_PATH = path.join(DATA_DIR, 'qr.png');
   const SESSION_DIR = path.join(DATA_DIR, 'whatsapp-auth');
   const LEGACY_AUTH_DIR = path.join(__dirname, '.wwebjs_auth');
+  const CACHE_DIR = path.join(DATA_DIR, '.wwebjs_cache');
+  const DEFAULT_WEB_VERSION = '2.3000.1031490220-alpha';
+  const webVersionConfig = String(getConfig('WEB_VERSION', '')).trim();
+  const WEB_VERSION = webVersionConfig || DEFAULT_WEB_VERSION;
 
   const RESET_SESSION = String(getConfig('RESET_SESSION', 'false')).toLowerCase() === 'true';
   if (RESET_SESSION) {
@@ -45,6 +49,7 @@ function initMessaging({ onMessage, onCall, onReady }) {
   }
 
   fs.mkdirSync(SESSION_DIR, { recursive: true });
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
 
   client = new Client({
     authStrategy: new LocalAuth({ dataPath: SESSION_DIR }),
@@ -57,7 +62,12 @@ function initMessaging({ onMessage, onCall, onReady }) {
         '--no-zygote',               // don't use a zygote process
         '--disable-gpu'              // no GPU in container
       ]
-    }
+    },
+    webVersionCache: {
+      type: 'local',
+      path: CACHE_DIR
+    },
+    webVersion: WEB_VERSION
   });
 
   client.on('qr', async qr => {


### PR DESCRIPTION
### Motivation
- Ensure the WhatsApp Web client version can be controlled from configuration to avoid unexpected upstream breakages and allow a sensible default to be used when not provided.
- Persist the downloaded web client artifacts locally to speed startup and avoid repeated network fetches by enabling a local webVersion cache directory.

### Description
- Add `CACHE_DIR` as `path.join(DATA_DIR, '.wwebjs_cache')` and create it with `fs.mkdirSync` during initialization.
- Add `DEFAULT_WEB_VERSION = '2.3000.1031490220-alpha'` and read `WEB_VERSION` from `getConfig('WEB_VERSION', '')` falling back to the default when blank.
- Configure the `Client` with `webVersion: WEB_VERSION` and `webVersionCache: { type: 'local', path: CACHE_DIR }` so the local cache directory is used.
- Keep existing session handling and creation of `SESSION_DIR` and preserve legacy auth cleanup logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971cc2f1600832296d85a2b5a640c8d)