### PR TITLE
Release workflow: recursively update GateGPT version in package-lock.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,27 @@ jobs:
           const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
           pkg.version = newVer;
           fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
           const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
-          lock.version = newVer;
-          if (lock.packages && lock.packages['']) {
-            lock.packages[''].version = newVer;
-          }
+          const updateGateGPTVersions = (value) => {
+            if (Array.isArray(value)) {
+              for (const item of value) {
+                updateGateGPTVersions(item);
+              }
+              return;
+            }
+            if (!value || typeof value !== 'object') {
+              return;
+            }
+            if (value.name === 'GateGPT' && typeof value.version === 'string') {
+              value.version = newVer;
+            }
+            for (const child of Object.values(value)) {
+              updateGateGPTVersions(child);
+            }
+          };
+          updateGateGPTVersions(lock);
+
           fs.writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
           NODE
           git ls-files -z | grep -vzE "$EXCLUDE_RE" | xargs -0 perl -pi -e "s/\\Q$OLD_TAG\\E/$NEW_TAG/g; s/\\Q$OLD_VER\\E/$NEW_VER/g"


### PR DESCRIPTION
### Motivation
- Ensure the release workflow reliably updates the GateGPT package version in `package-lock.json` regardless of lockfile shape instead of only touching top-level fields. 

### Description
- Replace direct `lock.version`/`lock.packages['']` assignments with a recursive `updateGateGPTVersions` walker that finds objects where `name === 'GateGPT'` and sets their `version` to `NEW_VER`.
- Continue updating `gategpt/GateGPT/package.json` and write both files back as pretty-printed JSON with a trailing newline.
- Keep existing git staging, commit, tagging, and push steps unchanged.

### Testing
- No automated tests were run for this workflow change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c79490708322b32ea334ce9275d7)