### PR TITLE
Use stable chat identifiers for WhatsApp LID chats

### DIFF
--- a/gategpt/GateGPT/__tests__/basic.test.js
+++ b/gategpt/GateGPT/__tests__/basic.test.js
@@ -35,6 +35,7 @@ jest.mock('../messaging', () => {
     sendAuto,
     isAutoMessage: () => false,
     getChatById: async () => chat,
+    getPhoneJidForChatId: jest.fn(async () => null),
     Location,
     getStatus: () => ({ ready: true, qrId: 0 }),
     __handlers: handlers,
@@ -62,13 +63,15 @@ if (fs.existsSync(ignoreListPath)) fs.unlinkSync(ignoreListPath);
 
 require('../main');
 
-function createMessage(body) {
+function createMessage(body, overrides = {}) {
   return {
     body,
     fromMe: false,
     type: 'chat',
     timestamp: Date.now(),
-    getChat: async () => messaging.__chat
+    getChat: async () => messaging.__chat,
+    getContact: async () => ({ id: messaging.__chat.id }),
+    ...overrides
   };
 }
 
@@ -202,6 +205,33 @@ describe('delivery conversation', () => {
       '9999'
     );
     expect(getOtp('ABC123')).toBeUndefined();
+  });
+
+  test('uses resolved phone JID instead of transient LID for ignore list', async () => {
+    messaging.getPhoneJidForChatId.mockResolvedValueOnce('48531858363@c.us');
+    messaging.__chat.id = { _serialized: '11455315341467@lid', server: 'lid' };
+
+    await messaging.__handlers.onMessage(createMessage('!ignore'));
+
+    expect(messaging.sendAuto).toHaveBeenLastCalledWith(
+      messaging.__chat,
+      'Ignoring 48531858363@c.us'
+    );
+
+    messaging.__chat.id = { _serialized: 'test@c.us' };
+    messaging.getPhoneJidForChatId.mockResolvedValue(null);
+  });
+
+  test('ignores status broadcast messages before loading a chat', async () => {
+    const getChat = jest.fn(async () => messaging.__chat);
+
+    await messaging.__handlers.onMessage(createMessage('status update', {
+      from: 'status@broadcast',
+      isStatus: true,
+      getChat
+    }));
+
+    expect(getChat).not.toHaveBeenCalled();
   });
 
   test('still transcribes ignored voice messages and sends Whisper pushover', async () => {

--- a/gategpt/GateGPT/actions.js
+++ b/gategpt/GateGPT/actions.js
@@ -48,15 +48,16 @@ async function openGate(chat, convo) {
     convo.gateCloseTimer = setTimeout(async () => {
       try {
         await axios.post(getConfig('GATE_CLOSE_URL'), {});
-        console.log(`🔐 Gate closed for ${chat.id._serialized}`);
-        const trackings = getTrackingsForPhone(chat.id._serialized);
+        const deliveryChatId = convo.chatId || chat.id._serialized;
+        console.log(`🔐 Gate closed for ${deliveryChatId}`);
+        const trackings = getTrackingsForPhone(deliveryChatId);
         trackings.forEach(t => {
-          setStatus(t, 'delivered', chat.id._serialized);
-          removeTrackingForPhone(chat.id._serialized, t);
+          setStatus(t, 'delivered', deliveryChatId);
+          removeTrackingForPhone(deliveryChatId, t);
         });
         sendPushoverNotification(
           'GateGPT',
-          `Delivery from ${chat.id._serialized} handled.`
+          `Delivery from ${deliveryChatId} handled.`
         );
       } catch (err) {
         console.error('❌ Failed to close gate:', err.message);
@@ -67,14 +68,14 @@ async function openGate(chat, convo) {
       convo.sentLocation = false;
       convo.delivering = false;
       convo.gateCloseTimer = null;
-      console.log(`🕓 Instant mode OFF for ${chat.id._serialized}`);
+      console.log(`🕓 Instant mode OFF for ${convo.chatId || chat.id._serialized}`);
     }, getConfig('AUTO_CLOSE_DELAY_MS', 120000));
 
     if (convo.instantTimer) clearTimeout(convo.instantTimer);
     convo.instantTimer = setTimeout(() => {
       convo.instant = false;
       convo.triggered = false;
-      console.log(`🕓 Instant mode OFF for ${chat.id._serialized}`);
+      console.log(`🕓 Instant mode OFF for ${convo.chatId || chat.id._serialized}`);
     }, getConfig('AUTO_CLOSE_DELAY_MS', 120000));
   } catch (err) {
     console.error('❌ Gate open failed:', err.message);

--- a/gategpt/GateGPT/chatIdentity.js
+++ b/gategpt/GateGPT/chatIdentity.js
@@ -1,0 +1,89 @@
+const USER_JID_RE = /^\d+@(c\.us|s\.whatsapp\.net)$/i;
+const LID_JID_RE = /^\d+@lid$/i;
+const GROUP_JID_RE = /@g\.us$/i;
+const STATUS_BROADCAST_JID = 'status@broadcast';
+
+function serializedId(value) {
+  if (!value) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value._serialized === 'string') return value._serialized;
+  return null;
+}
+
+function normalizeUserJid(jid) {
+  if (typeof jid !== 'string') return null;
+  const normalized = jid.trim();
+  if (!USER_JID_RE.test(normalized)) return null;
+  return normalized.replace(/@s\.whatsapp\.net$/i, '@c.us');
+}
+
+function isGroupJid(jid) {
+  return typeof jid === 'string' && GROUP_JID_RE.test(jid);
+}
+
+function isStatusBroadcastJid(jid) {
+  return typeof jid === 'string' && jid.toLowerCase() === STATUS_BROADCAST_JID;
+}
+
+function isLidJid(jid) {
+  return typeof jid === 'string' && LID_JID_RE.test(jid);
+}
+
+function chatRawId(chat) {
+  return serializedId(chat?.id) || serializedId(chat);
+}
+
+function phoneJidFromContact(contact) {
+  const contactId = normalizeUserJid(serializedId(contact?.id));
+  if (contactId) return contactId;
+
+  // In whatsapp-web.js, `number` is only safe as a phone number when the
+  // contact id itself is not a LID.  A LID user part is also just digits, so
+  // blindly trusting contact.number would turn privacy IDs into fake phones.
+  const server = contact?.id?.server;
+  if (server && server !== 'lid' && /^\d{6,15}$/.test(String(contact?.number || ''))) {
+    return `${contact.number}@c.us`;
+  }
+
+  return null;
+}
+
+async function resolveChatPrimaryId(chat, message, { resolvePhoneJid } = {}) {
+  const rawId = chatRawId(chat) || serializedId(message?.id?.remote) || message?.from;
+  const directPhone = normalizeUserJid(rawId);
+  if (directPhone || isGroupJid(rawId) || isStatusBroadcastJid(rawId)) {
+    return directPhone || rawId;
+  }
+
+  if (typeof resolvePhoneJid === 'function' && rawId) {
+    try {
+      const resolved = normalizeUserJid(await resolvePhoneJid(rawId));
+      if (resolved) return resolved;
+    } catch (err) {
+      console.warn(`⚠️  Failed to resolve WhatsApp LID ${rawId}: ${err.message}`);
+    }
+  }
+
+  if (typeof message?.getContact === 'function') {
+    try {
+      const contact = await message.getContact();
+      const phoneJid = phoneJidFromContact(contact);
+      if (phoneJid) return phoneJid;
+    } catch (err) {
+      console.warn(`⚠️  Failed to read contact for ${rawId || 'unknown chat'}: ${err.message}`);
+    }
+  }
+
+  return rawId;
+}
+
+module.exports = {
+  STATUS_BROADCAST_JID,
+  chatRawId,
+  isGroupJid,
+  isLidJid,
+  isStatusBroadcastJid,
+  normalizeUserJid,
+  phoneJidFromContact,
+  resolveChatPrimaryId
+};

--- a/gategpt/GateGPT/main.js
+++ b/gategpt/GateGPT/main.js
@@ -15,7 +15,8 @@ const {
   initMessaging,
   sendAuto,
   isAutoMessage,
-  getChatById
+  getChatById,
+  getPhoneJidForChatId
 } = require('./messaging');
 const { initServer } = require('./server');
 const { sendLocation, openGate } = require('./actions');
@@ -28,7 +29,12 @@ const {
   getTrackingsForPhone
 } = require('./otp');
 const { setStatus } = require('./deliveryLog');
-const { isChannelMessage, isChannelChatError } = require('./messageFilters');
+const { resolveChatPrimaryId, chatRawId, isGroupJid } = require('./chatIdentity');
+const {
+  isChannelMessage,
+  isChannelChatError,
+  isStatusBroadcastMessage
+} = require('./messageFilters');
 
 initLogging();
 initServer();
@@ -76,7 +82,11 @@ function shouldHandleOtp(msg) {
 }
 
 async function handleMessage(message) {
-  if (isAutoMessage(message) || isChannelMessage(message)) return;
+  if (
+    isAutoMessage(message) ||
+    isChannelMessage(message) ||
+    isStatusBroadcastMessage(message)
+  ) return;
 
   let chat;
   try {
@@ -86,7 +96,10 @@ async function handleMessage(message) {
     throw err;
   }
   await mirrorIncomingMessage(message, chat);
-  const chatId = chat.id._serialized;
+  const rawChatId = chatRawId(chat);
+  const chatId = await resolveChatPrimaryId(chat, message, {
+    resolvePhoneJid: getPhoneJidForChatId
+  });
   const msgText = (message.body || '').trim().toLowerCase();
 
   if (msgText === '!ignore') {
@@ -122,7 +135,7 @@ async function handleMessage(message) {
     message.type = 'chat';
   }
 
-  if (ignoredChats.has(chatId) || chat.id.server === 'g.us') {
+  if (ignoredChats.has(chatId) || isGroupJid(rawChatId)) {
     console.log(`🚫 Ignored chat or group: ${chatId}`);
     return;
   }
@@ -155,11 +168,13 @@ async function handleMessage(message) {
       history: [],
       triggered: false,
       sentLocation: false,
-      delivering: false
+      delivering: false,
+      chatId
     });
   }
 
   const convo = conversations.get(chatId);
+  convo.chatId = chatId;
   if (!message.fromMe && convo.sentLocation && !convo.delivering) {
     const trackings = getTrackingsForPhone(chatId);
     trackings.forEach(t => setStatus(t, 'delivering', chatId));
@@ -207,7 +222,7 @@ async function handleMessage(message) {
 }
 
 async function handleAIResponse(chat, convo) {
-  console.log(`💬 Sending GPT reply to ${chat.id._serialized}`);
+  console.log(`💬 Sending GPT reply to ${convo.chatId}`);
   const { reply, actions } = await askChatGPT(convo.messages);
   let trimmed = reply;
 
@@ -222,11 +237,11 @@ async function handleAIResponse(chat, convo) {
         break;
       case 'associate_tracking_number':
         if (action.args?.tracking_number) {
-          associateTracking(chat.id._serialized, action.args.tracking_number);
+          associateTracking(convo.chatId, action.args.tracking_number);
         }
         break;
       case 'resolve_otp':
-        await resolveOtp(chat);
+        await resolveOtp(chat, convo.chatId);
         break;
       case 'send_otp':
         if (action.args?.tracking_number) {
@@ -246,7 +261,7 @@ async function handleAIResponse(chat, convo) {
       convo.triggered = false;
       convo.sentLocation = false;
       convo.delivering = false;
-      console.log(`🕓 Instant mode OFF for ${chat.id._serialized}`);
+      console.log(`🕓 Instant mode OFF for ${convo.chatId}`);
     }, getConfig('AUTO_CLOSE_DELAY_MS', 120000));
   }
 }

--- a/gategpt/GateGPT/messageFilters.js
+++ b/gategpt/GateGPT/messageFilters.js
@@ -1,4 +1,5 @@
 const CHANNEL_JID_RE = /@\w*newsletter\b/i;
+const STATUS_BROADCAST_JID = 'status@broadcast';
 
 function extractMessageJids(message) {
   const ids = [
@@ -21,6 +22,13 @@ function isChannelMessage(message) {
   return extractMessageJids(message).some(jid => CHANNEL_JID_RE.test(jid));
 }
 
+function isStatusBroadcastMessage(message) {
+  if (message?.isStatus) return true;
+  return extractMessageJids(message).some(
+    jid => jid.toLowerCase() === STATUS_BROADCAST_JID
+  );
+}
+
 function isChannelChatError(err) {
   const message = String(err?.message || '');
   const stack = String(err?.stack || '');
@@ -34,7 +42,9 @@ function isChannelChatError(err) {
 
 module.exports = {
   CHANNEL_JID_RE,
+  STATUS_BROADCAST_JID,
   extractMessageJids,
   isChannelMessage,
+  isStatusBroadcastMessage,
   isChannelChatError
 };

--- a/gategpt/GateGPT/messaging.js
+++ b/gategpt/GateGPT/messaging.js
@@ -46,6 +46,12 @@ async function getChatById(id) {
   return client.getChatById(id);
 }
 
+async function getPhoneJidForChatId(id) {
+  if (!client || typeof client.getContactLidAndPhone !== 'function') return null;
+  const [mapping] = await client.getContactLidAndPhone([id]);
+  return mapping?.pn || null;
+}
+
 function initMessaging({ onMessage, onCall, onReady }) {
   const DATA_DIR = getConfig('SESSION_DIR', __dirname);
   fs.mkdirSync(DATA_DIR, { recursive: true });
@@ -153,6 +159,7 @@ module.exports = {
   sendAuto,
   isAutoMessage,
   getChatById,
+  getPhoneJidForChatId,
   Location,
   getStatus
 };

--- a/gategpt/GateGPT/otp.js
+++ b/gategpt/GateGPT/otp.js
@@ -260,9 +260,9 @@ async function processOtpMessage(message) {
   }
 }
 
-async function resolveOtp(chat) {
+async function resolveOtp(chat, chatId = chat.id._serialized) {
   cleanupExpired();
-  const phone = chat.id._serialized;
+  const phone = chatId;
   const otps = readJson(OTP_FILE, {});
   const allTrackings = Object.keys(otps);
   if (!allTrackings.length) {

--- a/gategpt/GateGPT/public/app.js
+++ b/gategpt/GateGPT/public/app.js
@@ -80,7 +80,9 @@ function renderDeliveries(deliveries, otps) {
   deliveries.forEach(d => {
     const tr = document.createElement('tr');
     const otp = otps[d.tracking]?.otp || '';
-    const phoneRaw = d.chatId ? d.chatId.split('@')[0] : '';
+    const chatRaw = d.chatId || '';
+    const phoneRaw = /^\d+@c\.us$/i.test(chatRaw) ? chatRaw.split('@')[0] : '';
+    const displayChatId = phoneRaw || chatRaw;
     const icon = statusIcons[d.status] || 'question-circle';
     const trackingTd = document.createElement('td');
     trackingTd.textContent = d.tracking || '';
@@ -107,6 +109,8 @@ function renderDeliveries(deliveries, otps) {
       link.rel = 'noopener';
       link.textContent = phoneRaw;
       phoneTd.appendChild(link);
+    } else {
+      phoneTd.textContent = displayChatId;
     }
     tr.appendChild(phoneTd);
 


### PR DESCRIPTION
### Motivation
- WhatsApp is rolling out privacy-preserving LID identifiers (`...@lid`) which can break long-lived keys that used phone-number JIDs like `...@c.us` for ignore lists, tracking and delivery bookkeeping.
- The app needs a single stable primary identifier per conversation so ignore lists, OTP/tracking maps and the dashboard do not split between transient LIDs and phone JIDs.
- Group chats should still be ignored by their group JID (`@g.us`), and `status@broadcast` updates must be filtered out before attempting to load a chat.

### Description
- Add a new `chatIdentity.js` helper that normalizes/inspects JIDs and exposes `resolveChatPrimaryId(...)`, `chatRawId(...)` and helpers to detect `@g.us`, `@lid` and `status@broadcast` values, and to safely derive a phone JID from contact data.
- Expose `getPhoneJidForChatId()` from the messaging wrapper to call `client.getContactLidAndPhone()` when available so LID -> phone mappings can be resolved by the runtime.
- Switch message handling to compute a single normalized `chatId = resolveChatPrimaryId(...)` and use that consistently for `!ignore` / `!unignore`, conversation keys, `associateTracking`, OTP resolution, delivery `setStatus`, gate-close bookkeeping and dashboard display.
- Add `isStatusBroadcastMessage(...)` and short-circuit status broadcasts before calling `message.getChat()` so status messages do not trigger chat handling.
- Update `otp.js` to accept an explicit `chatId` for OTP resolution and `actions.js`/`main.js` to use `convo.chatId` when marking deliveries or closing gates.
- Update the dashboard (`public/app.js`) to show a clickable `wa.me` link only when `chatId` is a resolved numeric phone JID (pattern `\d+@c.us`), otherwise display the raw chat identifier.
- Add/adjust unit tests in `__tests__/basic.test.js` to cover resolving LID -> phone JID for the ignore list and to assert `status@broadcast` messages are ignored before chat loading.

### Testing
- Ran `npm test -- --runInBand` and observed all test suites pass, but the process left open handles; behavior expected for the long-lived app lifecycle in tests.
- Ran `npm test -- --runInBand --forceExit` and all suites passed: 5 test suites, 17 tests passed (no failures).
- Unit tests added/updated: extended `__tests__/basic.test.js` with tests for LID -> phone JID ignore-list normalization and status-broadcast filtering; these tests passed in the CI run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090add7c0c8322964f6faf8ddade41)